### PR TITLE
Parameterize wait/retries for contacting Chromium

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ const {
 })();
 ```
 
-Default is trying to connect to Chromium 5 times with a 500 milisecond interval between each attempt. You can customize timeout/attempts:
+Default is trying to connect to Chromium 5 times with a 500 milisecond interval between each attempt. You can customize timeout/attempts by passing arguments to `dockerRunChromium`:
 
 ```javascript
 // ...
@@ -44,6 +44,8 @@ const webSocketUri = await dockerRunChromium({
     retryInterval: 5000 // 5 seconds
 });
 ```
+
+Or by defining environment variables `DOCKER_CHROMIUM_MAX_ATTEMPTS` and `DOCKER_CHROMIUM_RETRY_INTERVAL`. Passing arguments to `dockerRunChromium` takes precedence over environment variables.
 
 ## How it works
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,16 @@ const {
 })();
 ```
 
+Default is trying to connect to Chromium 5 times with a 500 milisecond interval between each attempt. You can customize timeout/attempts:
+
+```javascript
+// ...
+const webSocketUri = await dockerRunChromium({
+    maxAttempts: 10,
+    retryInterval: 5000 // 5 seconds
+});
+```
+
 ## How it works
 
 `docker-chromium` pulls a pre-built Docker image running a version of Chromium specified by you from a Docker Hub repository. You can then fetch the WebSocket URI to connect to the instance in your own application. If the pre-built image is unavailable or corrupt (rare case), a backup mechanism is in place, which builds the image from scratch locally instead.

--- a/lib/index.js
+++ b/lib/index.js
@@ -135,7 +135,11 @@ const dockerConfig = async ({ flags, revision }) => {
     }
 };
 
-const dockerRun = async ({ maxAttempts = 5, retryInterval = 500 } = {}) => {
+const dockerRun = async ({ maxAttempts, retryInterval } = {}) => {
+    maxAttempts = maxAttempts || process.env.DOCKER_CHROMIUM_MAX_ATTEMPTS || 5;
+    retryInterval =
+        retryInterval || process.env.DOCKER_CHROMIUM_RETRY_INTERVAL || 500;
+
     await dockerBuild();
     await dockerUp();
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -135,7 +135,7 @@ const dockerConfig = async ({ flags, revision }) => {
     }
 };
 
-const dockerRun = async ({ maxAttempts, retryInterval }) => {
+const dockerRun = async ({ maxAttempts = 5, retryInterval = 500 } = {}) => {
     await dockerBuild();
     await dockerUp();
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -76,7 +76,7 @@ const dockerDown = async () => {
     }
 };
 
-const contactChromium = async ({ config, maxAttempts }) => {
+const contactChromium = async ({ config, maxAttempts, retryInterval }) => {
     let count = 1;
     console.log(`${CONSOLE_PREFIX} Contacting Chromium in container...`.green);
 
@@ -92,7 +92,7 @@ const contactChromium = async ({ config, maxAttempts }) => {
                             `${CONSOLE_PREFIX} Attempt #${count}`.yellow
                         );
                         resolve(await tryRequest());
-                    }, 500);
+                    }, retryInterval);
                 });
             }
             console.log(
@@ -135,7 +135,7 @@ const dockerConfig = async ({ flags, revision }) => {
     }
 };
 
-const dockerRun = async () => {
+const dockerRun = async ({ maxAttempts, retryInterval }) => {
     await dockerBuild();
     await dockerUp();
 
@@ -145,7 +145,8 @@ const dockerRun = async () => {
             json: true,
             resolveWithFullResponse: true
         },
-        maxAttempts: 5
+        maxAttempts,
+        retryInterval
     });
 
     const webSocketUri = res.body.webSocketDebuggerUrl;


### PR DESCRIPTION
Tries to solve #4 by making `dockerRunChromium` accept parameters for max attempts and time between attempts to connect to Chromium.