### PR TITLE
Add no-check-certificate flag to wget command

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update -qqy \
   
 ARG CHROMIUM_REVISION
 ARG CHROMIUM_DOWNLOAD_HOST
-RUN wget -q -O chrome.zip $CHROMIUM_DOWNLOAD_HOST/chromium-browser-snapshots/Linux_x64/$CHROMIUM_REVISION/chrome-linux.zip \
+RUN wget --no-check-certificate -q -O chrome.zip $CHROMIUM_DOWNLOAD_HOST/chromium-browser-snapshots/Linux_x64/$CHROMIUM_REVISION/chrome-linux.zip \
   && unzip chrome.zip \
   && rm chrome.zip \
   && ln -s $PWD/chrome-linux/chrome /usr/bin/google-chrome-unstable


### PR DESCRIPTION
We need also add ``--no-check-certificate`` flag to ``wget`` command in Dockerfile.

Docker is secure sandbox environment, so we do not need check SSL certificates, especially for custom servers.

I will be very grateful for merging this.  I need it to implement visual tests in my company.

It would be great if you will make a release with this change.